### PR TITLE
Detect inline header error instead of panicing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,11 +591,13 @@ impl Crazyradio {
         let answer_size = self.device_handle
             .read_bulk(0x81, &mut answer, Duration::from_secs(1))?;
 
-        if (answer_size < IN_HEADER_LENGTH) || ((answer[0] as usize) < answer_size) {
+        // The first bye of the answer is the size of the answer
+        // The minimum possible answer is 2 bytes [size, header]
+        if (answer_size < IN_HEADER_LENGTH) || ((answer[0] as usize) != answer_size) {
             return Err(Error::UsbProtocolError("Inline header malformed".to_string()));
         }
 
-        // Decode answer
+        // Decode answer, at this point we are sure that answer[0] is >= 2
         let payload_length = (answer[0] as usize) - 2;
         if let Some(ack_data) = ack_data {
             ack_data[0..payload_length]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,7 +594,7 @@ impl Crazyradio {
         // The first bye of the answer is the size of the answer
         // The minimum possible answer is 2 bytes [size, header]
         if (answer_size < IN_HEADER_LENGTH) || ((answer[0] as usize) != answer_size) {
-            return Err(Error::UsbProtocolError("Inline header malformed".to_string()));
+            return Err(Error::UsbProtocolError("Inline header from radio malformed, try to update your radio".to_string()));
         }
 
         // Decode answer, at this point we are sure that answer[0] is >= 2


### PR DESCRIPTION
In case of malformed inline-mode header, the current implementation panics.

This PR adds a protocolError field to the error type and return it in that case.