### PR TITLE
Return link quality information from radio

### DIFF
--- a/src/shared_radio.rs
+++ b/src/shared_radio.rs
@@ -133,6 +133,7 @@ impl SharedCrazyradio {
                 length: result.payload.len(),
                 power_detector: result.power_detector,
                 retry: result.retry,
+                rssi_dbm: result.rssi_dbm,
             },
             result.payload,
         ))
@@ -224,6 +225,7 @@ impl SharedCrazyradio {
                 length: result.payload.len(),
                 power_detector: result.power_detector,
                 retry: result.retry,
+                rssi_dbm: result.rssi_dbm,
             },
             result.payload,
         ))
@@ -344,6 +346,7 @@ struct SendPacketResult {
     payload: Vec<u8>,
     retry: usize,
     power_detector: bool,
+    rssi_dbm: Option<u8>,
 }
 struct ScanResult {
     found: Vec<Channel>,
@@ -382,6 +385,7 @@ fn send_packet(
         payload: ack_data,
         retry: ack.retry,
         power_detector: ack.power_detector,
+        rssi_dbm: ack.rssi_dbm,
     })
 }
 

--- a/src/shared_radio.rs
+++ b/src/shared_radio.rs
@@ -131,8 +131,8 @@ impl SharedCrazyradio {
             Ack {
                 received: result.acked,
                 length: result.payload.len(),
-                power_detector: false,
-                retry: 0,
+                power_detector: result.power_detector,
+                retry: result.retry,
             },
             result.payload,
         ))
@@ -222,8 +222,8 @@ impl SharedCrazyradio {
             Ack {
                 received: result.acked,
                 length: result.payload.len(),
-                power_detector: false,
-                retry: 0,
+                power_detector: result.power_detector,
+                retry: result.retry,
             },
             result.payload,
         ))
@@ -342,6 +342,8 @@ enum RadioCommand {
 struct SendPacketResult {
     acked: bool,
     payload: Vec<u8>,
+    retry: usize,
+    power_detector: bool,
 }
 struct ScanResult {
     found: Vec<Channel>,
@@ -378,6 +380,8 @@ fn send_packet(
     Ok(SendPacketResult {
         acked: ack.received,
         payload: ack_data,
+        retry: ack.retry,
+        power_detector: ack.power_detector,
     })
 }
 


### PR DESCRIPTION
Return link quality information for usage in the `crazyflie-link-rs` and `crazyflie-lib-rs`.

**NOTE:** This is an API breaking change