### PR TITLE
Drain IN EP when opening the radio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,22 @@ fn list_crazyradio_serials() -> Result<Vec<String>> {
     Ok(serials)
 }
 
+const USB_RX_DRAIN_MAX_PACKETS: usize = 64;
+
+fn drain_rx_queue_with<F>(mut read_bulk: F) -> usize
+where
+    F: FnMut(&mut [u8; 64]) -> std::result::Result<usize, rusb::Error>,
+{
+    let mut drain_buf = [0u8; 64];
+    let mut drained = 0;
+
+    while drained < USB_RX_DRAIN_MAX_PACKETS && read_bulk(&mut drain_buf).is_ok() {
+        drained += 1;
+    }
+
+    drained
+}
+
 enum UsbCommand {
     SetRadioChannel = 0x01,
     SetRadioAddress = 0x02,
@@ -230,6 +246,7 @@ impl Crazyradio {
         let device_handle = Arc::new(device.open()?);
 
         device_handle.claim_interface(0)?;
+        drain_rx_queue_with(|buf| device_handle.read_bulk(0x81, buf, Duration::from_millis(1)));
 
         // Make sure the dongle version is >= 0.5
         let version = device_desciptor.device_version();
@@ -286,6 +303,8 @@ impl Crazyradio {
         let prev_cache_settings = self.cache_settings;
         self.cache_settings = false;
 
+        self.drain_rx_queue();
+
         // Always exit sniffer mode unconditionally: a previous session may
         // have left the radio in sniffer mode. Ignore errors since older
         // firmware without sniffer support will reject the command.
@@ -315,7 +334,16 @@ impl Crazyradio {
 
         self.cache_settings = prev_cache_settings;
 
+        self.drain_rx_queue();
+
         Ok(())
+    }
+
+    fn drain_rx_queue(&self) -> usize {
+        drain_rx_queue_with(|buf| {
+            self.device_handle
+                .read_bulk(0x81, buf, Duration::from_millis(1))
+        })
     }
 
     /// Enable or disable caching of settings
@@ -1198,5 +1226,27 @@ mod tests {
         let result = serde_json::to_string(&test_channel);
 
         assert!(matches!(result, Ok(str) if str == "42"));
+    }
+
+    #[test]
+    fn drain_rx_queue_reads_until_the_endpoint_is_empty() {
+        let mut responses = vec![Ok(3usize), Ok(2usize), Err(rusb::Error::Timeout)];
+
+        let drained = super::drain_rx_queue_with(|_| responses.remove(0));
+
+        assert_eq!(drained, 2);
+    }
+
+    #[test]
+    fn drain_rx_queue_stops_after_max_packets() {
+        let mut reads = 0;
+
+        let drained = super::drain_rx_queue_with(|_| {
+            reads += 1;
+            Ok(1usize)
+        });
+
+        assert_eq!(drained, super::USB_RX_DRAIN_MAX_PACKETS);
+        assert_eq!(reads, super::USB_RX_DRAIN_MAX_PACKETS);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,18 +104,24 @@ fn list_crazyradio_serials() -> Result<Vec<String>> {
 
 const USB_RX_DRAIN_MAX_PACKETS: usize = 64;
 
-fn drain_rx_queue_with<F>(mut read_bulk: F) -> usize
+fn drain_rx_queue_with<F>(mut read_bulk: F) -> Result<usize>
 where
     F: FnMut(&mut [u8; 64]) -> std::result::Result<usize, rusb::Error>,
 {
     let mut drain_buf = [0u8; 64];
     let mut drained = 0;
 
-    while drained < USB_RX_DRAIN_MAX_PACKETS && read_bulk(&mut drain_buf).is_ok() {
+    while read_bulk(&mut drain_buf).is_ok() {
         drained += 1;
+
+        if drained == USB_RX_DRAIN_MAX_PACKETS {
+            return Err(Error::UsbProtocolError(format!(
+                "USB RX endpoint still not empty after draining {USB_RX_DRAIN_MAX_PACKETS} packets"
+            )));
+        }
     }
 
-    drained
+    Ok(drained)
 }
 
 enum UsbCommand {
@@ -246,7 +252,6 @@ impl Crazyradio {
         let device_handle = Arc::new(device.open()?);
 
         device_handle.claim_interface(0)?;
-        drain_rx_queue_with(|buf| device_handle.read_bulk(0x81, buf, Duration::from_millis(1)));
 
         // Make sure the dongle version is >= 0.5
         let version = device_desciptor.device_version();
@@ -303,7 +308,9 @@ impl Crazyradio {
         let prev_cache_settings = self.cache_settings;
         self.cache_settings = false;
 
-        self.drain_rx_queue();
+        // Clear packets left in the USB IN endpoint by a previous session
+        // before changing the radio state.
+        self.drain_rx_queue()?;
 
         // Always exit sniffer mode unconditionally: a previous session may
         // have left the radio in sniffer mode. Ignore errors since older
@@ -334,12 +341,15 @@ impl Crazyradio {
 
         self.cache_settings = prev_cache_settings;
 
-        self.drain_rx_queue();
+        // Drain again after the mode switch/reset sequence. Packets can still
+        // arrive while the firmware exits sniffer mode, so the initial drain
+        // alone does not guarantee the endpoint is empty.
+        self.drain_rx_queue()?;
 
         Ok(())
     }
 
-    fn drain_rx_queue(&self) -> usize {
+    fn drain_rx_queue(&self) -> Result<usize> {
         drain_rx_queue_with(|buf| {
             self.device_handle
                 .read_bulk(0x81, buf, Duration::from_millis(1))
@@ -1234,11 +1244,11 @@ mod tests {
 
         let drained = super::drain_rx_queue_with(|_| responses.remove(0));
 
-        assert_eq!(drained, 2);
+        assert!(matches!(drained, Ok(2)));
     }
 
     #[test]
-    fn drain_rx_queue_stops_after_max_packets() {
+    fn drain_rx_queue_returns_error_after_max_packets() {
         let mut reads = 0;
 
         let drained = super::drain_rx_queue_with(|_| {
@@ -1246,7 +1256,7 @@ mod tests {
             Ok(1usize)
         });
 
-        assert_eq!(drained, super::USB_RX_DRAIN_MAX_PACKETS);
+        assert!(matches!(drained, Err(super::Error::UsbProtocolError(_))));
         assert_eq!(reads, super::USB_RX_DRAIN_MAX_PACKETS);
     }
 }


### PR DESCRIPTION
When opening a Crazyradio, there can be packets left in the USB IN endpoint from a previous session. This can happen for example if the previous process sent a packet in inline mode and exited before reading the corresponding IN response, or if the radio was used in sniffer mode and packets were still queued when the process exited or switched mode.

If these stale packets are left in the endpoint, the next user of the radio can get out of sync and read an old packet instead of the response to the current operation. This PR drains the IN endpoint during reset so that we start from a known empty USB RX queue before using the radio.

The queue is drained both before and after resetting the radio state:
   - before reset, to clear packets left by the previous session
   - after reset, because packets can still arrive while the firmware exits sniffer mode / changes radio state

If the endpoint does not become empty after a bounded number of packets, this is treated as a USB protocol error instead of silently continuing. This avoids hanging forever and makes the failure visible if draining does not work.

A possible alternative would be a firmware-side soft reset command that resets the radio internal state machines, but for now this keeps the fix host-side and does not require a firmware update.